### PR TITLE
Added composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "pschmitt/tags",
+    "type": "phile-plugin",
+    "license": "MIT",
+    "description": "Tags for Phile CMS",
+    "homepage": "https://github.com/pschmitt/phileTags",
+    "keywords": ["cms", "phile", "plugin", "tags"],
+    "authors": [
+        {
+            "name": "Philipp Schmitt",
+            "email": "p@lxl.io",
+            "homepage": "http://lxl.io/"
+        }
+    ],
+    "require": {
+        "phile-cms/phile": ">=1.0",
+        "phile-cms/plugin-installer-plugin": ">=1.0"
+    }
+}


### PR DESCRIPTION
Since I don't use git and want to use composer I created a composer.json file for you.

You need to register at https://packagist.org/ and get an API token that you can then use on your Github repository to add a service hook so that the package on packagist gets updated.
Of course, you have to submit phileTags to Packagist. But, hey: don't you want to be (more) famous? :)
