### PR TITLE
fix cache race condition

### DIFF
--- a/Classes/Plugin.php
+++ b/Classes/Plugin.php
@@ -28,6 +28,7 @@ class Plugin extends \Phile\Plugin\AbstractPlugin implements \Phile\Gateway\Even
         \Phile\Event::registerEvent('before_render_template', $this);
         \Phile\Event::registerEvent('after_read_file_meta', $this);
         \Phile\Event::registerEvent('request_uri', $this);
+        \Phile\Event::registerEvent('after_parse_content', $this);
         $this->config = \Phile\Registry::get('Phile_Settings');
 
         // init
@@ -47,8 +48,9 @@ class Plugin extends \Phile\Plugin\AbstractPlugin implements \Phile\Gateway\Even
             if (isset($data['meta']['tags'])) {
                 $data['meta']['tags_array'] = $this->tags_convert($data['meta']['tags']);
             }
+        } elseif ($eventKey === 'after_parse_content') {
             if ($this->is_tag) {
-                $data['meta']['template'] = $this->tag_template;
+                $data['page']->getMeta()->set('template', $this->tag_template);
             }
         }
     }


### PR DESCRIPTION
Problem: Assume a page is uncached (by build-in phpFastCache page-cache). Then a request for the tag-index-page comes in. On this request the page gets cached with the meta `template` set to "tag". If the cached page is visited afterwards it is served with the wrong "tag" template.

Solution: move the setting of the template for the tag-page later in the cycle so that it's not cached as meta property.
